### PR TITLE
Fix: pre-ambulo e assinaturas da banca

### DIFF
--- a/dissertacao/graduacao/monografia.tex
+++ b/dissertacao/graduacao/monografia.tex
@@ -94,7 +94,7 @@
   \par
   Ciência da Computação}
 \tipotrabalho{Trabalho de Conclusão de Curso}
-\preambulo{Trabalho de Conclusão de Curso do Curso de Ciência da Computação da Universidade Estadual Paulista ``Júlio de Mesquita Filho'', Faculdade de Ciências, Campus Bauru.}
+\preambulo{Trabalho de Conclusão de Curso do Curso de Bacharelado em Ciência da Computação da Universidade Estadual Paulista ``Júlio de Mesquita Filho'', Faculdade de Ciências, Campus Bauru.}
 
 
 % --------------------------------------------------------
@@ -247,15 +247,15 @@
 	\assinatura{\textbf{\imprimirorientador} \\ Orientador\\
 		Universidade Estadual Paulista "Júlio de Mesquita Filho"\\
 		Faculdade de Ciências \\
-	Departamento de Ciência da Computação}
+	Departamento de Computação}
 	\assinatura{\textbf{Professor Convidado 1} \\
 		Universidade Estadual Paulista "Júlio de Mesquita Filho"\\
 		Faculdade de Ciências \\
-	Departamento de Ciência da Computação}
+	Departamento de Computação}
 	\assinatura{\textbf{Professor Convidado 2} \\
 		Universidade Estadual Paulista "Júlio de Mesquita Filho"\\
 		Faculdade de Ciências \\
-	Departamento de Ciência da Computação}
+	Departamento de Computação}
 	\begin{center}
 		\vspace*{0.5cm}
 		\par

--- a/dissertacao/graduacao/monografia.tex
+++ b/dissertacao/graduacao/monografia.tex
@@ -92,7 +92,7 @@
   \par
   Faculdade de Ciências
   \par
-  Ciência da Computação}
+  Bacharelado em Ciência da Computação}
 \tipotrabalho{Trabalho de Conclusão de Curso}
 \preambulo{Trabalho de Conclusão de Curso do Curso de Bacharelado em Ciência da Computação da Universidade Estadual Paulista ``Júlio de Mesquita Filho'', Faculdade de Ciências, Campus Bauru.}
 


### PR DESCRIPTION
Olá, estou sugerindo um pull-request com essas correções apontadas durante a revisão da minha monografia.

1) No preâmbulo, está faltando o título de "Bacharelado" referente ao curso, aparentemente isso já foi corrigido no arquivo da proposta, mas ainda não havia sido corrigido no arquivo da monografia.

2) Nas assinaturas da banca, o departamento estava com "Departamento de Ciência da Computação" por padrão, foi feita a correção para "Departamento de Computação".

Mesmo o template sendo direcionado para a Faculdade de Ciências, como muitos dos usuários são do curso de BCC, acredito que as alterações poderiam ser benéficas.

Muito obrigado pelo projeto!