### PR TITLE
Fix: Ordem dos elementos da banca organizadora trocada.

### DIFF
--- a/dissertacao/graduacao/monografia.tex
+++ b/dissertacao/graduacao/monografia.tex
@@ -245,17 +245,17 @@
 	\end{center}
 	\center Banca Examinadora
 	\assinatura{\textbf{\imprimirorientador} \\ Orientador\\
-		Universidade Estadual Paulista "Júlio de Mesquita Filho"\\
+		Departamento de Computação \\
 		Faculdade de Ciências \\
-	Departamento de Computação}
+	Universidade Estadual Paulista "Júlio de Mesquita Filho"}
 	\assinatura{\textbf{Professor Convidado 1} \\
-		Universidade Estadual Paulista "Júlio de Mesquita Filho"\\
+		Departamento de Computação \\
 		Faculdade de Ciências \\
-	Departamento de Computação}
+	Universidade Estadual Paulista "Júlio de Mesquita Filho"}
 	\assinatura{\textbf{Professor Convidado 2} \\
-		Universidade Estadual Paulista "Júlio de Mesquita Filho"\\
+		Departamento de Computação \\
 		Faculdade de Ciências \\
-	Departamento de Computação}
+	Universidade Estadual Paulista "Júlio de Mesquita Filho"}
 	\begin{center}
 		\vspace*{0.5cm}
 		\par


### PR DESCRIPTION
Segundo as correções da bancas de computação de 2020,  para cada participante, na página da banca examinadora, a ordem das afiliações é:

1. departamento;
2. faculdade (FC nesse caso);
3. universidade.

Se não me engano, essa correção aconteceu para vários alunos.